### PR TITLE
Docker proc bump

### DIFF
--- a/omero-base/Dockerfile
+++ b/omero-base/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get install -y \
 RUN useradd -m omero
 RUN su - omero -c "virtualenv --system-site-packages ~/venv"
 RUN su - omero -c "~/venv/bin/pip install -U yaclifw && ~/venv/bin/pip install -U omego"
+RUN apt-get install -y git
 
 USER omero
 ENV HOME /home/omero

--- a/omero-conda/Dockerfile
+++ b/omero-conda/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:12.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-RUN apt-get update && apt-get install -y bzip2 unzip wget openjdk-7-jre-headless
+RUN apt-get update && \
+    apt-get install -y bzip2 unzip wget openjdk-7-jre-headless \
+                       make g++ patch \
+                       libmcpp-dev libbz2-dev libexpat1-dev libssl-dev libdb5.1++-dev
 
 RUN useradd -m omero
 
@@ -14,14 +17,11 @@ RUN /opt/anaconda/bin/conda install --yes numpy && \
     /opt/anaconda/bin/conda install --yes scipy && \
     /opt/anaconda/bin/conda install --yes matplotlib && \
     /opt/anaconda/bin/conda install --yes ipython && \
-    /opt/anaconda/bin/conda install --yes pytables
+    /opt/anaconda/bin/conda install --yes pytables && \
+    /opt/anaconda/bin/conda install --yes pip
 
 RUN echo 'export PATH=/opt/anaconda/bin:$PATH' >> .bashrc
 
-RUN apt-get install -y make g++
-RUN apt-get install -y libmcpp-dev libbz2-dev libexpat1-dev libssl-dev libdb5.1++-dev
-
-RUN apt-get install -y patch
 ADD Makefile.patch /tmp/
 ADD ice-build /tmp/ice-build
 RUN sh /tmp/ice-build && rm /tmp/ice-build

--- a/omero-process/Dockerfile
+++ b/omero-process/Dockerfile
@@ -2,13 +2,12 @@ FROM openmicroscopy/omero-conda
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root
-RUN cd /tmp && \
-    wget http://downloads.openmicroscopy.org/omero/5.0.1/artifacts/OMERO.py-5.0.1-ice34-b21.zip && \
-    echo '05d60953b4eff3fd7019055ea42ac1f6  OMERO.py-5.0.1-ice34-b21.zip' > OMERO.py-5.0.1-ice34-b21.zip.md5 && \
-    md5sum --check OMERO.py-5.0.1-ice34-b21.zip.md5 && \
-    unzip -d /opt OMERO.py-5.0.1-ice34-b21.zip && \
-    ln -s /opt/OMERO.py-5.0.1-ice34-b21 /opt/omero && \
-    rm OMERO.py-5.0.1-ice34-b21.zip
+RUN cd /opt && \
+    apt-get install -y git && \
+    /opt/anaconda/bin/pip install git+https://github.com/ome/omego && \
+    /opt/anaconda/bin/omego download python --branch=OMERO-5.1-latest && \
+    ln -s $(find . -name 'OMERO.py*' -type d) /opt/omero && \
+    rm OMERO.py*.zip
 
 USER omero
 ENV PYTHONPATH /opt/omero/lib/python


### PR DESCRIPTION
In the process of getting `DockerProcessor` up and running again, it was necessary to update the `omero-process` image. A couple of questions:
- Should I rework this to be on centos?
- Is this actually `omero-py` rather than `omero-process`? `/opt/omero/bin/omero` does work.
- ETA for omego release :) /cc @manics
