### PR TITLE
Add 5.1 source code in a tags file

### DIFF
--- a/tags/5.1.0/Dockerfile
+++ b/tags/5.1.0/Dockerfile
@@ -1,0 +1,11 @@
+FROM mini/base
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN apk-install git && \
+    mkdir /src
+
+RUN time git clone --bare --depth=1 -b v5.1.0 git://github.com/ome/scripts/ /src/scripts.git
+RUN time git clone --bare --depth=1 -b v5.1.0 git://github.com/openmicroscopy/openmicroscopy /src/omero.git
+RUN time git clone --bare --depth=1 -b v5.1.0 git://github.com/openmicroscopy/bioformats /src/bio-formats.git
+
+WORKDIR /src

--- a/tags/5.1.1/Dockerfile
+++ b/tags/5.1.1/Dockerfile
@@ -1,0 +1,17 @@
+FROM openmicroscopy/tags:5.1.0
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN cd /src/scripts.git && \
+	time git fetch \
+		git://github.com/ome/scripts/ \
+		refs/tags/v5.1.1:refs/tags/v5.1.1
+
+RUN cd /src/omero.git && \
+	time git fetch -v --progress --depth=20 \
+		git://github.com/openmicroscopy/openmicroscopy/ \
+		refs/tags/v5.1.1:refs/tags/v5.1.1
+
+RUN cd /src/bio-formats.git && \
+	time git fetch -v --progress --depth=20 \
+		git://github.com/openmicroscopy/bioformats/ \
+		refs/tags/v5.1.1:refs/tags/v5.1.1


### PR DESCRIPTION
In order to simplify the building of code inside of docker,
we store shallow tags of the main OME repositories in a single
file.  The created images can be used as data containers into
which one can merge other branches to build custom code. As
decoupling continues, each "tag" can become a representation
of an entire release, i.e. which tags of which repositories
have been tested together.

#### Discussion ####

There are a few open questions about this strategy that it would be good to get feedback on. The goal is have an easy (fast!) way of getting git sources into docker-compose builds. See https://github.com/joshmoore/devspace/blob/a5a15de2124d6429b8d115d12b5c183c14b275b7/docker-compose.yml#L47 for an example usage.

 * Is the shallow strategy here useful or will it lead to issues down the road?
 * Should these images be built by docker hub? If so, when do we start supporting them?

cc: @sbesson @manics 