### PR TITLE
Pull all upstream base images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ BASES=$(grep -h '^FROM' */Dockerfile | \
 echo Pulling $BASES
 for base in $BASES
 do
-    docker pull $base
+    docker pull $base || true
 done
 
 for docker in $(python graph.py --order)

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,14 @@
 set -e
 PREFIX=openmicroscopy
+
+BASES=$(grep -h '^FROM' */Dockerfile | \
+	sed -re 's|FROM\s+([A-Za-z0-9/-]+)(:.+)?|\1|' | sort -u)
+echo Pulling $BASES
+for base in $BASES
+do
+    docker pull $base
+done
+
 for docker in $(python graph.py --order)
 do
     cd $docker

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,13 @@ PREFIX=openmicroscopy
 
 BASES=$(grep -h '^FROM' */Dockerfile | \
 	sed -re 's|FROM\s+([A-Za-z0-9/-]+)(:.+)?|\1|' | sort -u)
-echo Pulling $BASES
 for base in $BASES
 do
-    docker pull $base || true
+    if [ "${base#$PREFIX/}" = "$base" ]; then
+        docker pull $base
+    else
+        echo Not pulling $base
+    fi
 done
 
 for docker in $(python graph.py --order)

--- a/omero-conda/Dockerfile
+++ b/omero-conda/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:14.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update -y && \
+        apt-get install -y --no-install-recommends \
         bzip2 \
         unzip \
         wget \


### PR DESCRIPTION
Ensure the latest upstream images are used for builds.
Also run `apt-get update` in `omero-conda` to avoid an installation error