### PR TITLE
Centos-7 with a default omero ssh account and full sudo

### DIFF
--- a/omero-ssh/Dockerfile
+++ b/omero-ssh/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:centos7
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN yum install -y sudo openssh-server openssh-clients && \
+	yum clean all
+
+RUN sed -i \
+	's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' \
+	/etc/pam.d/sshd && \
+	/usr/bin/ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key \
+	-C '' -N ''
+
+RUN useradd omero && \
+	echo 'omero:omero' | chpasswd omero &&\
+	echo "omero ALL= (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/omero
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-eD"]


### PR DESCRIPTION
This is mostly for internal testing, e.g. for ansible playbooks.