### PR TITLE
omero-deploy updates

### DIFF
--- a/omero-conda/Dockerfile
+++ b/omero-conda/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /tmp && \
     rm Miniconda-3.7.0-Linux-x86_64.sh
 
 RUN /opt/anaconda/bin/conda install --yes \
-    numpy scipy matplotlib ipython pytables pip
+    numpy scipy matplotlib ipython pytables pillow pip
 
 RUN echo 'export PATH=/opt/anaconda/bin:$PATH' >> .bashrc
 

--- a/omero-deploy/Dockerfile
+++ b/omero-deploy/Dockerfile
@@ -45,6 +45,6 @@ RUN ln -s /opt/Ice-3.5/bin/* /usr/local/bin/ && \
 VOLUME ["/data"]
 EXPOSE 22 80 4063 4064 5432
 
+# Pass a single argument "" to disable OMERO.server installation
 ENTRYPOINT ["/run.sh"]
-# Todo: Change omego to download the latest release automatically
-CMD ["https://downloads.openmicroscopy.org/omero/5.1.1/artifacts/OMERO.server-5.1.1-ice35-b43.zip"]
+CMD ["--release", "latest"]

--- a/omero-deploy/Dockerfile
+++ b/omero-deploy/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -y && \
     sudo \
     vim
 
-RUN echo 'omero:omero' | chpasswd omero
 RUN /opt/anaconda/bin/pip install omego
 
 RUN mkdir /var/run/sshd && \

--- a/omero-deploy/Dockerfile
+++ b/omero-deploy/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update -y && \
     openssh-server \
     nginx \
     postgresql \
-    python-pip \
     supervisor \
     sudo \
     vim

--- a/omero-deploy/Dockerfile
+++ b/omero-deploy/Dockerfile
@@ -41,7 +41,7 @@ RUN ln -s /opt/Ice-3.5/bin/* /usr/local/bin/ && \
     ln -s /opt/anaconda/bin/* /usr/local/bin/
 
 VOLUME ["/data"]
-EXPOSE 22 80 4063 4064 5432
+EXPOSE 22 80 4063 4064
 
 # Pass a single argument "" to disable OMERO.server installation
 ENTRYPOINT ["/run.sh"]

--- a/omero-deploy/README.md
+++ b/omero-deploy/README.md
@@ -22,9 +22,14 @@ Pass `""` to disable the automatic server installation. This will start all the 
 Passwords
 ---------
 
-Use the environment variable `OMERO_PASSWORD` to change the omero system password (default unset), and the OMERO.server root password (default `omero`):
+Define the following environment variables to set the initial passwords:
+- `OMERO_PASSWORD`: OMERO.server root password (default `omero`, ignored if an existing OMERO database is being used)
+- `SYSTEM_PASSWORD`: The omero user system password (default unset, must be set to allow ssh login)
 
-    docker run -d -e OMERO_PASSWORD=password omero-deploy
+Example:
+
+    docker run -d -e SYSTEM_PASSWORD=abc -e OMERO_PASSWORD=def omero-deploy
+
 
 Data volumes
 ------------

--- a/omero-deploy/README.md
+++ b/omero-deploy/README.md
@@ -7,19 +7,24 @@ To download, install and run the default server:
 
     docker run -d -p 80:8080 -p 4063:4063 -p 4064:4064 omero-deploy
 
-[omego](https://github.com/ome/omego/) is used to download and install the server when the image is started. Command arguments are appended to the `omego` command line. For example, the URL to an alternative OMERO.server zip can be passed:
+[omego](https://github.com/ome/omego/) is used to download and install the server when the image is started (defaults to the latest release). Command arguments are appended to the `omego` command line. For example, an alternative release, a CI build, or the URL to an alternative OMERO.server zip, can be passed:
 
-    docker run -d omero-deploy https://downloads.openmicroscopy.org/omero/5.1.0/artifacts/OMERO.server-5.1.0-ice35-b40.zip
-
-A server can also be obtained from the OME's continuous integration server:
-
-    docker run -d omero-deploy --branch OMERO-5.1-merge-build
+    docker run -d omero-deploy --release 5.1.4
+    docker run -d omero-deploy --branch OMERO-DEV-merge-build
+    docker run -d omero-deploy https://download.example.org/OMERO.server-X.zip
 
 Pass `""` to disable the automatic server installation. This will start all the required services so the server can be installed manually:
 
     CID=$(docker run -d omero-deploy "")
-    docker exec $CID /omero-setup https://downloads.openmicroscopy.org/omero/5.1.1/artifacts/OMERO.server-5.1.1-ice35-b43.zip
+    docker exec $CID /omero-setup --release latest
 
+
+Passwords
+---------
+
+Use the environment variable `OMERO_PASSWORD` to change the omero system password (default unset), and the OMERO.server root password (default `omero`):
+
+    docker run -d -e OMERO_PASSWORD=password omero-deploy
 
 Data volumes
 ------------
@@ -37,4 +42,3 @@ Notes
 This image is designed for testing and debugging OMERO, and includes:
 - ssh
 - password-less sudo for the `omero` user
-- An exposed PostgreSQL server port

--- a/omero-deploy/postgresql
+++ b/omero-deploy/postgresql
@@ -13,12 +13,9 @@ if [ ! -f "$PGDATA/PG_VERSION" ]; then
     install -d -m 755 -o omero -g omero "$PGDATA"
     su - omero -c "$PGBIN/initdb -D $PGDATA -E UTF8"
     echo sed -i -re 's/^(host.*)trust/\1md5/' "$PGDATA/pg_hba.conf"
-    echo 'host all all 0.0.0.0/0 md5' >> "$PGDATA/pg_hba.conf"
 else
     chown -R omero "$PGDATA"
 fi
-
-sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA/postgresql.conf"
 
 chown -R omero /var/run/postgresql
 

--- a/omero-deploy/run.sh
+++ b/omero-deploy/run.sh
@@ -2,9 +2,13 @@
 
 set -e
 
+if [ -n "$SYSTEM_PASSWORD" ]; then
+	echo "Setting omero system password"
+	echo "omero:$SYSTEM_PASSWORD" | chpasswd
+fi
+
 if [ -n "$OMERO_PASSWORD" ]; then
-	echo "Setting omero password"
-	echo "omero:$OMERO_PASSWORD" | chpasswd
+	echo "Overriding omero root password"
 	OMEGO_ARGS="--rootpass \"$OMERO_PASSWORD\""
 fi
 

--- a/omero-deploy/run.sh
+++ b/omero-deploy/run.sh
@@ -2,12 +2,18 @@
 
 set -e
 
+if [ -n "$OMERO_PASSWORD" ]; then
+	echo "Setting omero password"
+	echo "omero:$OMERO_PASSWORD" | chpasswd
+	OMEGO_ARGS="--rootpass \"$OMERO_PASSWORD\""
+fi
+
 if [ $# -gt 0 -a -n "$*" ]; then
-	OMEGO_ARGS="$@"
-	export OMEGO_ARGS
+	OMEGO_ARGS="$OMEGO_ARGS $@"
 else
 	mv /etc/supervisor/conf.d/omero.conf /etc/supervisor/conf.d/omero.disabled
 fi
+export OMEGO_ARGS
 
 mkdir -p /data/supervisor
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
- Add missing pillow python dependency
- Disable postgres on external IP
- OMERO system and root passwords can be overridden using environment vars
- `ssh omero@host` only works if a password was set (default unset)
- default to latest OMERO.server release

See [README.md](https://github.com/manics/ome-docker/blob/omero-deploy-updates/omero-deploy/README.md)