### PR TITLE
If ~omero/OMERO.server exists don't install a new server

### DIFF
--- a/omero-deploy/Dockerfile
+++ b/omero-deploy/Dockerfile
@@ -13,9 +13,10 @@ RUN apt-get update -y && \
     vim
 
 RUN /opt/anaconda/bin/pip install \
-    omego \
     "django<1.9" \
     gunicorn
+RUN /opt/anaconda/bin/pip install \
+    https://github.com/ome/omego/archive/master.zip
 
 RUN mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' \

--- a/omero-deploy/omero-setup
+++ b/omero-deploy/omero-setup
@@ -37,11 +37,18 @@ if stat -t /data/omero.preload/* > /dev/null 2>&1; then
     done
 fi
 
-su - omero -c \
-    "omego install $DBCMD --dbname omero --sym OMERO.server $PRESTART $OPTS"
-
-echo "Starting omero"
 OMERO=~omero/OMERO.server/bin/omero
+
+if [ -e ~omero/OMERO.server ]; then
+    echo "OMERO.server found, starting existing server"
+    su - omero -c "$OMERO admin start"
+    su - omero -c "$OMERO web start"
+else
+    su - omero -c \
+        "omego install $DBCMD --dbname omero --sym OMERO.server $PRESTART $OPTS"
+fi
+
+echo "Creating web configuration"
 su - omero -c "$OMERO web config nginx" > /etc/nginx/conf.d/omero-web.conf
 
 echo "Restarting nginx"


### PR DESCRIPTION
This should only occur when restarting an existing container. Fixes https://github.com/ome/ome-docker/issues/15