### PR TITLE
omero ssh images

### DIFF
--- a/omero-ssh-c6/Dockerfile
+++ b/omero-ssh-c6/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:centos7
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN yum install -y sudo openssh-server openssh-clients && \
+	yum clean all
+
+RUN sed -i \
+	's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' \
+	/etc/pam.d/sshd && \
+	/usr/bin/ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key \
+	-C '' -N ''
+
+RUN useradd omero && \
+	echo 'omero:omero' | chpasswd omero &&\
+	echo "omero ALL= (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/omero
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-eD"]

--- a/omero-ssh-c6/Dockerfile
+++ b/omero-ssh-c6/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM centos:centos6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN yum install -y sudo openssh-server openssh-clients && \

--- a/omero-ssh-u1404/Dockerfile
+++ b/omero-ssh-u1404/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+RUN apt-get update -y && \
+    apt-get install -y openssh-server
+
+RUN mkdir /var/run/sshd && \
+    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' \
+    -i /etc/pam.d/sshd
+
+RUN useradd -m omero && \
+    chsh -s /bin/bash omero && \
+    echo 'omero:omero' | chpasswd omero && \
+    echo "omero ALL= (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/omero
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-eD"]


### PR DESCRIPTION
Centos 6 and Ubuntu 14.04 for interactive testing of OMERO setup instructions.

User: `omero` Password:` omero`

Since these are transient servers you should run `ssh -o UserKnownHostsFile=/dev/null omero@docker-ip` to avoid server keys being stored.