### PR TITLE
omero-deploy/postgresql: more robust parsing of psql --version

### DIFF
--- a/omero-deploy/postgresql
+++ b/omero-deploy/postgresql
@@ -4,7 +4,7 @@
 
 set -eux
 
-PGVER=$(psql --version | sed -re 's/^.+ ([0-9]\.+[0-9])\.[0-9]$/\1/')
+PGVER=$(psql --version | awk '{print $NF}' | cut -d '.' -f -2)
 PGDATA=${PGDATA:-/data/postgresql}
 PGBIN=/usr/lib/postgresql/$PGVER/bin
 


### PR DESCRIPTION
Current parsing assumes one-digit version components, so it fails with postgres 9.3.10. This patch should make the parsing more robust:
```
echo 'psql (PostgreSQL) 9.3.10' | awk '{print $NF}' | cut -d '.' -f -2
9.3
```