### PR TITLE
Disable interactive when installing docker-engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 # Upgrade to latest docker-engine
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y docker-engine
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get -q -o Dpkg::Options::="--force-confnew" install -y docker-engine
 
 install:
   - pip install -U docker-py


### PR DESCRIPTION
Travis is current failing during the installation of docker-engine, e.g. https://s3.amazonaws.com/archive.travis-ci.org/jobs/109312625/log.txt

```
Unpacking docker-engine (1.10.1-0~trusty) over (1.8.2-0~trusty) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Not building database; man-db/auto-update is not 'true'.
Processing triggers for ureadahead (0.100.0-16) ...
Setting up libsystemd-journal0:amd64 (204-5ubuntu20.18) ...
Setting up docker-engine (1.10.1-0~trusty) ...
Installing new version of config file /etc/init/docker.conf ...
Configuration file '/etc/default/docker'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** docker (Y/I/N/O/D/Z) [default=N] ? 
```

This should force the config to be overwritten