### PR TITLE
adressing ice 3.5 with 3.6 clash

### DIFF
--- a/omero-web/Dockerfile
+++ b/omero-web/Dockerfile
@@ -15,17 +15,20 @@ RUN yum install -y \
     python-pip python-devel python-virtualenv \
     numpy scipy python-matplotlib python-tables && \
     yum clean all
-  
-RUN curl -o /etc/yum.repos.d/zeroc-ice-el7.repo \
-    http://download.zeroc.com/Ice/3.5/el7/zeroc-ice-el7.repo
 
-RUN yum install -y ice ice-python ice-servers && \
+RUN curl -o /etc/yum.repos.d/zeroc-ice-el7.repo \
+    https://download.zeroc.com/rpm/zeroc-ice-el7.repo
+
+RUN yum install -y ice-all-runtime && \
     yum clean all
 
 RUN yum install -y \
     zlib-devel \
+    bzip2-devel \
     libjpeg-devel \
-    gcc && \
+    openssl-devel \
+    gcc \
+    gcc-c++ && \
     yum clean all
 
 # Install nginx

--- a/omero-web/omeroweb.sh
+++ b/omero-web/omeroweb.sh
@@ -35,6 +35,8 @@ fi
 ln -s ~omero/$OMERO_ZIP ~omero/OMERO.py && \
 rm $OMERO_ZIP.zip
 
+pip install zeroc-ice
+
 pip install --upgrade pip
 pip install --upgrade 'Pillow<3.0'
 pip install --upgrade -r ~omero/OMERO.py/share/web/requirements-py27-nginx.txt


### PR DESCRIPTION
Building this image failed for me since the rpms were ice 3.5. The proposed changes are more or less similar to what's in https://github.com/ome/omero-install/ for a centos 7 + ice 3.6 install.
